### PR TITLE
feat: Split syscall APIs with core implementations

### DIFF
--- a/ckb_syscall_apis.h
+++ b/ckb_syscall_apis.h
@@ -1,0 +1,41 @@
+#ifndef CKB_C_STDLIB_CKB_SYSCALL_APIS_H_
+#define CKB_C_STDLIB_CKB_SYSCALL_APIS_H_
+
+/*
+ * Syscall related APIs that will be shared and used in all CKB
+ * smart contract environments
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+int ckb_exit(int8_t code);
+int ckb_load_tx_hash(void* addr, uint64_t* len, size_t offset);
+int ckb_load_transaction(void* addr, uint64_t* len, size_t offset);
+int ckb_load_script_hash(void* addr, uint64_t* len, size_t offset);
+int ckb_load_script(void* addr, uint64_t* len, size_t offset);
+int ckb_debug(const char* s);
+
+int ckb_load_cell(void* addr, uint64_t* len, size_t offset, size_t index,
+                  size_t source);
+int ckb_load_input(void* addr, uint64_t* len, size_t offset, size_t index,
+                   size_t source);
+int ckb_load_header(void* addr, uint64_t* len, size_t offset, size_t index,
+                    size_t source);
+int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
+                     size_t source);
+int ckb_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
+                           size_t index, size_t source, size_t field);
+int ckb_load_header_by_field(void* addr, uint64_t* len, size_t offset,
+                             size_t index, size_t source, size_t field);
+int ckb_load_input_by_field(void* addr, uint64_t* len, size_t offset,
+                            size_t index, size_t source, size_t field);
+int ckb_load_cell_data(void* addr, uint64_t* len, size_t offset, size_t index,
+                       size_t source);
+
+int ckb_dlopen2(const uint8_t* dep_cell_hash, uint8_t hash_type,
+                uint8_t* aligned_addr, size_t aligned_size, void** handle,
+                size_t* consumed_size);
+void* ckb_dlsym(void* handle, const char* symbol);
+
+#endif /* CKB_C_STDLIB_CKB_SYSCALL_APIS_H_ */

--- a/ckb_syscalls.h
+++ b/ckb_syscalls.h
@@ -6,48 +6,7 @@
 #include <string.h>
 
 #include "ckb_consts.h"
-
-#define memory_barrier() asm volatile("fence" ::: "memory")
-
-static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
-                                      long _a3, long _a4, long _a5) {
-  register long a0 asm("a0") = _a0;
-  register long a1 asm("a1") = _a1;
-  register long a2 asm("a2") = _a2;
-  register long a3 asm("a3") = _a3;
-  register long a4 asm("a4") = _a4;
-  register long a5 asm("a5") = _a5;
-
-#ifdef __riscv_32e
-  register long syscall_id asm("t0") = n;
-#else
-  register long syscall_id asm("a7") = n;
-#endif
-
-  asm volatile("scall"
-               : "+r"(a0)
-               : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
-  /*
-   * Syscalls might modify memory sent as pointer, adding a barrier here ensures
-   * gcc won't do incorrect optimization.
-   */
-  memory_barrier();
-
-  return a0;
-}
-
-#define syscall(n, a, b, c, d, e, f)                                           \
-  __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), \
-                     (long)(f))
-
-int ckb_exit(int8_t code) { return syscall(SYS_exit, code, 0, 0, 0, 0, 0); }
-
-int ckb_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_tx_hash, addr, &inner_len, offset, 0, 0, 0);
-  *len = inner_len;
-  return ret;
-}
+#include "ckb_syscall_apis.h"
 
 int ckb_checked_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
   uint64_t old_len = *len;
@@ -58,29 +17,12 @@ int ckb_checked_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
   return ret;
 }
 
-int ckb_load_script_hash(void* addr, uint64_t* len, size_t offset) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_script_hash, addr, &inner_len, offset, 0, 0, 0);
-  *len = inner_len;
-  return ret;
-}
-
 int ckb_checked_load_script_hash(void* addr, uint64_t* len, size_t offset) {
   uint64_t old_len = *len;
   int ret = ckb_load_script_hash(addr, len, offset);
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_cell(void* addr, uint64_t* len, size_t offset, size_t index,
-                  size_t source) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_cell, addr, &inner_len, offset, index, source, 0);
-  *len = inner_len;
   return ret;
 }
 
@@ -94,15 +36,6 @@ int ckb_checked_load_cell(void* addr, uint64_t* len, size_t offset,
   return ret;
 }
 
-int ckb_load_input(void* addr, uint64_t* len, size_t offset, size_t index,
-                   size_t source) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_input, addr, &inner_len, offset, index, source, 0);
-  *len = inner_len;
-  return ret;
-}
-
 int ckb_checked_load_input(void* addr, uint64_t* len, size_t offset,
                            size_t index, size_t source) {
   uint64_t old_len = *len;
@@ -110,15 +43,6 @@ int ckb_checked_load_input(void* addr, uint64_t* len, size_t offset,
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_header(void* addr, uint64_t* len, size_t offset, size_t index,
-                    size_t source) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_header, addr, &inner_len, offset, index, source, 0);
-  *len = inner_len;
   return ret;
 }
 
@@ -132,15 +56,6 @@ int ckb_checked_load_header(void* addr, uint64_t* len, size_t offset,
   return ret;
 }
 
-int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
-                     size_t source) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_witness, addr, &inner_len, offset, index, source, 0);
-  *len = inner_len;
-  return ret;
-}
-
 int ckb_checked_load_witness(void* addr, uint64_t* len, size_t offset,
                              size_t index, size_t source) {
   uint64_t old_len = *len;
@@ -148,13 +63,6 @@ int ckb_checked_load_witness(void* addr, uint64_t* len, size_t offset,
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_script(void* addr, uint64_t* len, size_t offset) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_script, addr, &inner_len, offset, 0, 0, 0);
-  *len = inner_len;
   return ret;
 }
 
@@ -167,29 +75,12 @@ int ckb_checked_load_script(void* addr, uint64_t* len, size_t offset) {
   return ret;
 }
 
-int ckb_load_transaction(void* addr, uint64_t* len, size_t offset) {
-  volatile uint64_t inner_len = *len;
-  int ret =
-      syscall(SYS_ckb_load_transaction, addr, &inner_len, offset, 0, 0, 0);
-  *len = inner_len;
-  return ret;
-}
-
 int ckb_checked_load_transaction(void* addr, uint64_t* len, size_t offset) {
   uint64_t old_len = *len;
   int ret = ckb_load_transaction(addr, len, offset);
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
-                           size_t index, size_t source, size_t field) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_cell_by_field, addr, &inner_len, offset, index,
-                    source, field);
-  *len = inner_len;
   return ret;
 }
 
@@ -200,15 +91,6 @@ int ckb_checked_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_header_by_field(void* addr, uint64_t* len, size_t offset,
-                             size_t index, size_t source, size_t field) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_header_by_field, addr, &inner_len, offset,
-                    index, source, field);
-  *len = inner_len;
   return ret;
 }
 
@@ -223,15 +105,6 @@ int ckb_checked_load_header_by_field(void* addr, uint64_t* len, size_t offset,
   return ret;
 }
 
-int ckb_load_input_by_field(void* addr, uint64_t* len, size_t offset,
-                            size_t index, size_t source, size_t field) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_input_by_field, addr, &inner_len, offset,
-                    index, source, field);
-  *len = inner_len;
-  return ret;
-}
-
 int ckb_checked_load_input_by_field(void* addr, uint64_t* len, size_t offset,
                                     size_t index, size_t source, size_t field) {
   uint64_t old_len = *len;
@@ -239,21 +112,6 @@ int ckb_checked_load_input_by_field(void* addr, uint64_t* len, size_t offset,
   if (ret == CKB_SUCCESS && (*len) > old_len) {
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
-  return ret;
-}
-
-int ckb_load_cell_code(void* addr, size_t memory_size, size_t content_offset,
-                       size_t content_size, size_t index, size_t source) {
-  return syscall(SYS_ckb_load_cell_data_as_code, addr, memory_size,
-                 content_offset, content_size, index, source);
-}
-
-int ckb_load_cell_data(void* addr, uint64_t* len, size_t offset, size_t index,
-                       size_t source) {
-  volatile uint64_t inner_len = *len;
-  int ret = syscall(SYS_ckb_load_cell_data, addr, &inner_len, offset, index,
-                    source, 0);
-  *len = inner_len;
   return ret;
 }
 
@@ -265,10 +123,6 @@ int ckb_checked_load_cell_data(void* addr, uint64_t* len, size_t offset,
     ret = CKB_LENGTH_NOT_ENOUGH;
   }
   return ret;
-}
-
-int ckb_debug(const char* s) {
-  return syscall(SYS_ckb_debug, s, 0, 0, 0, 0, 0);
 }
 
 /* load the actual witness for the current type verify group.
@@ -361,5 +215,150 @@ int ckb_look_for_dep_with_hash2(const uint8_t* code_hash, uint8_t hash_type,
 int ckb_look_for_dep_with_hash(const uint8_t* data_hash, size_t* index) {
   return ckb_look_for_dep_with_hash2(data_hash, 0, index);
 }
+
+#ifndef CKB_STDLIB_NO_SYSCALL_IMPL
+
+#define memory_barrier() asm volatile("fence" ::: "memory")
+
+static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
+                                      long _a3, long _a4, long _a5) {
+  register long a0 asm("a0") = _a0;
+  register long a1 asm("a1") = _a1;
+  register long a2 asm("a2") = _a2;
+  register long a3 asm("a3") = _a3;
+  register long a4 asm("a4") = _a4;
+  register long a5 asm("a5") = _a5;
+
+#ifdef __riscv_32e
+  register long syscall_id asm("t0") = n;
+#else
+  register long syscall_id asm("a7") = n;
+#endif
+
+  asm volatile("scall"
+               : "+r"(a0)
+               : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
+  /*
+   * Syscalls might modify memory sent as pointer, adding a barrier here ensures
+   * gcc won't do incorrect optimization.
+   */
+  memory_barrier();
+
+  return a0;
+}
+
+#define syscall(n, a, b, c, d, e, f)                                           \
+  __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), \
+                     (long)(f))
+
+int ckb_exit(int8_t code) { return syscall(SYS_exit, code, 0, 0, 0, 0, 0); }
+
+int ckb_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_tx_hash, addr, &inner_len, offset, 0, 0, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_script_hash(void* addr, uint64_t* len, size_t offset) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_script_hash, addr, &inner_len, offset, 0, 0, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_cell(void* addr, uint64_t* len, size_t offset, size_t index,
+                  size_t source) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_cell, addr, &inner_len, offset, index, source, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_input(void* addr, uint64_t* len, size_t offset, size_t index,
+                   size_t source) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_input, addr, &inner_len, offset, index, source, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_header(void* addr, uint64_t* len, size_t offset, size_t index,
+                    size_t source) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_header, addr, &inner_len, offset, index, source, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
+                     size_t source) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_witness, addr, &inner_len, offset, index, source, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_script(void* addr, uint64_t* len, size_t offset) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_script, addr, &inner_len, offset, 0, 0, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_transaction(void* addr, uint64_t* len, size_t offset) {
+  volatile uint64_t inner_len = *len;
+  int ret =
+      syscall(SYS_ckb_load_transaction, addr, &inner_len, offset, 0, 0, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
+                           size_t index, size_t source, size_t field) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_cell_by_field, addr, &inner_len, offset, index,
+                    source, field);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_header_by_field(void* addr, uint64_t* len, size_t offset,
+                             size_t index, size_t source, size_t field) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_header_by_field, addr, &inner_len, offset,
+                    index, source, field);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_input_by_field(void* addr, uint64_t* len, size_t offset,
+                            size_t index, size_t source, size_t field) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_input_by_field, addr, &inner_len, offset,
+                    index, source, field);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_load_cell_data(void* addr, uint64_t* len, size_t offset, size_t index,
+                       size_t source) {
+  volatile uint64_t inner_len = *len;
+  int ret = syscall(SYS_ckb_load_cell_data, addr, &inner_len, offset, index,
+                    source, 0);
+  *len = inner_len;
+  return ret;
+}
+
+int ckb_debug(const char* s) {
+  return syscall(SYS_ckb_debug, s, 0, 0, 0, 0, 0);
+}
+
+#endif /* CKB_STDLIB_NO_SYSCALL_IMPL */
 
 #endif /* CKB_C_STDLIB_CKB_SYSCALLS_H_ */


### PR DESCRIPTION
This change defines a core set of CKB syscall APIs, it then separates
utility functions that can be built on top of the core syscall
APIs. As a result, the implementation of the core syscall APIs can be
swapped, without affecting the utility functions one layer above. This
enables simulator based solution, where we swap the core syscall APIs
with dummy functions, so the same smart contracts can be built
differently on multiple platforms: a RISC-V based version for
execution on chain, and a x86 version for profiling and auditing reason.