### PR TITLE
feat: Add ckb specific blake2b init

### DIFF
--- a/ckb_type_id.h
+++ b/ckb_type_id.h
@@ -130,7 +130,7 @@ int ckb_validate_type_id(const uint8_t type_id[32]) {
       return ret;
     }
     blake2b_state blake2b_ctx;
-    blake2b_init(&blake2b_ctx, 32);
+    ckb_blake2b_init(&blake2b_ctx, 32);
     blake2b_update(&blake2b_ctx, buffer, len);
     blake2b_update(&blake2b_ctx, (uint8_t*)(&index), sizeof(index));
     uint8_t expected_type_id[32];

--- a/simulator/blake2b_decl_only.h
+++ b/simulator/blake2b_decl_only.h
@@ -22,6 +22,7 @@ typedef struct blake2b_state__ {
 } blake2b_state;
 
 /* Streaming API */
+int ckb_blake2b_init(blake2b_state *S, size_t outlen);
 int blake2b_init(blake2b_state *S, size_t outlen);
 int blake2b_init_key(blake2b_state *S, size_t outlen, const void *key,
                      size_t keylen);

--- a/simulator/ckb_syscall_simulator.c
+++ b/simulator/ckb_syscall_simulator.c
@@ -123,7 +123,7 @@ void load_offset(uint8_t* source_buff, uint64_t source_size, void* addr,
 
 void blake2b_hash(void* ptr, size_t size, uint8_t* hash) {
   blake2b_state ctx;
-  blake2b_init(&ctx, HASH_SIZE);
+  ckb_blake2b_init(&ctx, HASH_SIZE);
   blake2b_update(&ctx, ptr, size);
   blake2b_final(&ctx, hash, HASH_SIZE);
 }


### PR DESCRIPTION
Historically, we've been forking blake2b C implementation to hardcode
CKB specific personalization directly in blake2b library. However,
this would run into a problem where deep down the hierarchy, a
dependency also brings in unmodified blake2b library. To work around
this problem, this change adds a new ckb_blake2b_init function, which
uses the correct CKB personalization, while also distinguishes from
the official version. This way we can prevent unnecessary confusions.