### PR TITLE
feat: create an alias function ckb_printf

### DIFF
--- a/libc/src/impl.c
+++ b/libc/src/impl.c
@@ -1204,10 +1204,20 @@ int printf(const char *format, ...) {
   ckb_debug(buf);
   return ret;
 }
+int ckb_printf(const char *format, ...) {
+  static char buf[CKB_C_STDLIB_PRINTF_BUFFER_SIZE];
+  va_list va;
+  va_start(va, format);
+  int ret = vsnprintf_(buf, CKB_C_STDLIB_PRINTF_BUFFER_SIZE, format, va);
+  va_end(va);
+  ckb_debug(buf);
+  return ret;
+}
 
 #else
 
 int printf(const char *format, ...) { return 0; }
+int ckb_printf(const char *format, ...) { return 0; }
 
 #endif /* CKB_C_STDLIB_PRINTF */
 

--- a/libc/stdio.h
+++ b/libc/stdio.h
@@ -46,6 +46,14 @@
  * compiling.
  */
 int printf(const char* format, ...);
+/*
+ * This function uses `ckb_debug` syscall to output formatted messages.
+ *
+ * Pass `-D CKB_C_STDLIB_PRINTF` flag to GCC to enable ckb_printf;
+ * If the flag is undefined the ckb_printf will be compiled as an empty
+ * function.
+ */
+int ckb_printf(const char* format, ...);
 int ckb_debug(const char* s);
 
 #endif /* CKB_C_STDLIB_STDIO_H_ */


### PR DESCRIPTION
Some library prebuilt with it's own libc, to avoid function name conflict, developers can use the alias name `ckb_printf` to instead `printf`.