### PR TITLE
WIP: feat(blake2b): use ror instruction to implement function rotr64

### DIFF
--- a/blake2b.h
+++ b/blake2b.h
@@ -156,7 +156,13 @@ static BLAKE2_INLINE void store64(void *dst, uint64_t w) {
 }
 
 static BLAKE2_INLINE uint64_t rotr64(const uint64_t w, const unsigned c) {
+#if defined(USE_B_EXTENSION)
+  uint64_t rd = 0;
+  __asm__ ("ror %0, %1, %2" : "=r"(rd) : "r"(w), "r"(c));
+  return rd;
+#else
   return (w >> c) | (w << (64 - c));
+#endif
 }
 
 /* prevents compiler optimizing out memset() */


### PR DESCRIPTION
This changes effectively improves the performance of blake2b.

**Bench code**

```c
#include <blake2b.h>
#include <stdint.h>

int main(int argc, const char* argv[]) {
    uint8_t result[32] = {0};
    uint8_t random_data[100] = {1,2,3,4,5};

    blake2b_state ctx;

    for (int i = 0; i < 10000; i++) {
        ckb_blake2b_init(&ctx, 32);
        blake2b_update(&ctx, random_data, sizeof(random_data));
        blake2b_final(&ctx, result, sizeof(result));
        random_data[0] = result[0];
    }

    return result[0];
}
```

**Test steps**

```
$ docker run -it -v $(pwd):/src nervos/ckb-riscv-gnu-toolchain:bionic-20211214 /bin/bash
$ cd src

# Build with rv64imc
$ riscv64-unknown-elf-gcc -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections  -I. -I./libc -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g -march=rv64imc -Wl,-static -Wl,--gc-sections -o build/bench_blake2b_imc bench_blake2b.c

# Build with rv64imc_zba_zbb_zbc
$ riscv64-unknown-elf-gcc -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections  -I. -I./libc -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g -march=rv64imc_zba_zbb_zbc -DUSE_B_EXTENSION -Wl,-static -Wl,--gc-sections -o build/bench_blake2b_b bench_blake2b.c

$ ~/src/ckb-vm-run/target/release/asm build/bench_blake2b_imc 
# ... ... cycles=45340648

$ ~/src/ckb-vm-run/target/release/asm build/bench_blake2b_b
$ ... ... cycles=38660648
```

> `~/src/ckb-vm-run/target/release/asm` is built from  https://github.com/mohanson/ckb-vm-run