### PR TITLE
Fix bug when new toolchain

### DIFF
--- a/libc/src/impl.c
+++ b/libc/src/impl.c
@@ -398,6 +398,7 @@ static void cycle(size_t width, unsigned char *ar[], int n) {
     }
     width -= l;
   }
+  ar[n] = NULL;
 }
 
 /* shl() and shr() need n > 0 */


### PR DESCRIPTION
When using the [latest toolchain](https://hub.docker.com/layers/nervos/ckb-riscv-gnu-toolchain/gnu-jammy-20230214/images/sha256-d3f649ef8079395eb25a21ceaeb15674f47eaa2d8cc23adc8bcdae3d5abce6ec?context=explore), there will be some errors 
