### PR TITLE
Error are ignored dangling-pointer only when GCC12

### DIFF
--- a/libc/src/impl.c
+++ b/libc/src/impl.c
@@ -379,7 +379,7 @@ static inline int pntz(size_t p[2]) {
   return 0;
 }
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (__GNUC__ == 12)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
@@ -405,7 +405,7 @@ static void cycle(size_t width, unsigned char *ar[], int n) {
   }
 }
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (__GNUC__ == 12)
 #pragma GCC diagnostic pop
 #endif
 

--- a/libc/src/impl.c
+++ b/libc/src/impl.c
@@ -379,7 +379,7 @@ static inline int pntz(size_t p[2]) {
   return 0;
 }
 
-#if defined(__GNUC__) && (__GNUC__ == 12)
+#if defined(__GNUC__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
@@ -405,7 +405,7 @@ static void cycle(size_t width, unsigned char *ar[], int n) {
   }
 }
 
-#if defined(__GNUC__) && (__GNUC__ == 12)
+#if defined(__GNUC__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
[This PR](https://github.com/nervosnetwork/ckb-c-stdlib/pull/44) has problems under the old version of toolchain, here will judge the GCC version.