### PR TITLE
Remove CKB_C_STDLIB_PRINTF

### DIFF
--- a/molecule/molecule2_reader.h
+++ b/molecule/molecule2_reader.h
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-#define CKB_C_STDLIB_PRINTF
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
This macro shouldn't be defined here.
