### PR TITLE
Adjusting the spawn syscall

### DIFF
--- a/ckb_consts.h
+++ b/ckb_consts.h
@@ -26,7 +26,7 @@
 #define SYS_ckb_pipe 2604
 #define SYS_ckb_write 2605
 #define SYS_ckb_read 2606
-#define SYS_ckb_inherited_fd 2607
+#define SYS_ckb_inherited_fds 2607
 #define SYS_ckb_close 2608
 
 #define CKB_SUCCESS 0

--- a/ckb_syscall_apis.h
+++ b/ckb_syscall_apis.h
@@ -53,6 +53,10 @@ typedef struct spawn_args_t {
 
 int ckb_spawn(size_t index, size_t source, size_t place, size_t bounds,
               spawn_args_t* spawn_args);
+
+int ckb_spawn_cell(const uint8_t* code_hash, uint8_t hash_type, uint32_t offset,
+                   uint32_t length, spawn_args_t* spawn_args);
+
 int ckb_wait(uint64_t pid, int8_t* exit_code);
 
 uint64_t ckb_process_id();
@@ -63,8 +67,11 @@ int ckb_read(uint64_t fd, void* buffer, size_t* length);
 
 int ckb_write(uint64_t fd, const void* buffer, size_t* length);
 
-int ckb_inherited_file_descriptors(uint64_t* fd, size_t* length);
+int ckb_inherited_fds(uint64_t* fds, size_t* length);
 
 int ckb_close(uint64_t fd);
+
+int ckb_load_block_extension(void* addr, uint64_t* len, size_t offset,
+                             size_t index, size_t source);
 
 #endif /* CKB_C_STDLIB_CKB_SYSCALL_APIS_H_ */

--- a/ckb_syscalls.h
+++ b/ckb_syscalls.h
@@ -382,6 +382,18 @@ int ckb_spawn(size_t index, size_t source, size_t place, size_t bounds,
   return syscall(SYS_ckb_spawn, index, source, place, bounds, spawn_args, 0);
 }
 
+int ckb_spawn_cell(const uint8_t* code_hash, uint8_t hash_type, uint32_t offset,
+                   uint32_t length, spawn_args_t* spawn_args) {
+  size_t index = SIZE_MAX;
+  int ret = ckb_look_for_dep_with_hash2(code_hash, hash_type, &index);
+  if (ret != CKB_SUCCESS) {
+    return ret;
+  }
+  size_t bounds = ((size_t)offset << 32) | length;
+  return syscall(SYS_ckb_spawn, index, CKB_SOURCE_CELL_DEP, 0, bounds,
+                 spawn_args, 0);
+}
+
 int ckb_wait(uint64_t pid, int8_t* exit_code) {
   return syscall(SYS_ckb_wait, pid, exit_code, 0, 0, 0, 0);
 }
@@ -414,9 +426,9 @@ int ckb_load_block_extension(void* addr, uint64_t* len, size_t offset,
                  0);
 }
 
-int ckb_inherited_file_descriptors(uint64_t* fd, size_t* length) {
+int ckb_inherited_fds(uint64_t* fds, size_t* length) {
   volatile size_t l = *length;
-  int ret = syscall(SYS_ckb_inherited_fd, fd, &l, 0, 0, 0, 0);
+  int ret = syscall(SYS_ckb_inherited_fds, fd, &l, 0, 0, 0, 0);
   *length = l;
   return ret;
 }

--- a/ckb_syscalls.h
+++ b/ckb_syscalls.h
@@ -428,7 +428,7 @@ int ckb_load_block_extension(void* addr, uint64_t* len, size_t offset,
 
 int ckb_inherited_fds(uint64_t* fds, size_t* length) {
   volatile size_t l = *length;
-  int ret = syscall(SYS_ckb_inherited_fds, fd, &l, 0, 0, 0, 0);
+  int ret = syscall(SYS_ckb_inherited_fds, fds, &l, 0, 0, 0, 0);
   *length = l;
   return ret;
 }


### PR DESCRIPTION
- Rename `SYS_ckb_inherited_fd ` to `SYS_ckb_inherited_fds`
- Rename `ckb_inherited_file_descriptors` to `ckb_inherited_fds`
- Add `ckb_spawn_cell`
- Add `ckb_load_block_extension` in `ckb_syscall_apis.h`