### PR TITLE
Weak-alias syscall functions for replacing in certain cases

### DIFF
--- a/ckb_raw_syscalls.h
+++ b/ckb_raw_syscalls.h
@@ -19,6 +19,7 @@
 
 long default_internal_syscall(long n, long _a0, long _a1, long _a2, long _a3,
                               long _a4, long _a5) {
+#ifdef __riscv
   register long a0 asm("a0") = _a0;
   register long a1 asm("a1") = _a1;
   register long a2 asm("a2") = _a2;
@@ -42,6 +43,16 @@ long default_internal_syscall(long n, long _a0, long _a1, long _a2, long _a3,
   memory_barrier();
 
   return a0;
+#else
+  (void)n;
+  (void)_a0;
+  (void)_a1;
+  (void)_a2;
+  (void)_a3;
+  (void)_a4;
+  (void)_a5;
+  return -1;
+#endif
 }
 weak_alias(default_internal_syscall, __internal_syscall);
 

--- a/ckb_raw_syscalls.h
+++ b/ckb_raw_syscalls.h
@@ -10,8 +10,10 @@
  * From
  * https://git.musl-libc.org/cgit/musl/tree/src/include/features.h?id=86373b4999bfd9a9379bc4a3ca877b1c80a2a340#n8
  */
+#ifndef weak_alias
 #define weak_alias(old, new) \
   extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+#endif
 
 #define memory_barrier() asm volatile("fence" ::: "memory")
 

--- a/ckb_raw_syscalls.h
+++ b/ckb_raw_syscalls.h
@@ -6,10 +6,17 @@
 
 #ifndef CKB_STDLIB_NO_SYSCALL_IMPL
 
+/*
+ * From
+ * https://git.musl-libc.org/cgit/musl/tree/src/include/features.h?id=86373b4999bfd9a9379bc4a3ca877b1c80a2a340#n8
+ */
+#define weak_alias(old, new) \
+  extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+
 #define memory_barrier() asm volatile("fence" ::: "memory")
 
-static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
-                                      long _a3, long _a4, long _a5) {
+long default_internal_syscall(long n, long _a0, long _a1, long _a2, long _a3,
+                              long _a4, long _a5) {
   register long a0 asm("a0") = _a0;
   register long a1 asm("a1") = _a1;
   register long a2 asm("a2") = _a2;
@@ -34,182 +41,218 @@ static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
 
   return a0;
 }
+weak_alias(default_internal_syscall, __internal_syscall);
 
 #define syscall(n, a, b, c, d, e, f)                                           \
   __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), \
                      (long)(f))
 
-int ckb_exit(int8_t code) { return syscall(SYS_exit, code, 0, 0, 0, 0, 0); }
+int default_ckb_exit(int8_t code) {
+  return syscall(SYS_exit, code, 0, 0, 0, 0, 0);
+}
+weak_alias(default_ckb_exit, ckb_exit);
 
-int ckb_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
+int default_ckb_load_tx_hash(void* addr, uint64_t* len, size_t offset) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_tx_hash, addr, &inner_len, offset, 0, 0, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_tx_hash, ckb_load_tx_hash);
 
-int ckb_load_script_hash(void* addr, uint64_t* len, size_t offset) {
+int default_ckb_load_script_hash(void* addr, uint64_t* len, size_t offset) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_script_hash, addr, &inner_len, offset, 0, 0, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_script_hash, ckb_load_script_hash);
 
-int ckb_load_cell(void* addr, uint64_t* len, size_t offset, size_t index,
-                  size_t source) {
+int default_ckb_load_cell(void* addr, uint64_t* len, size_t offset,
+                          size_t index, size_t source) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_cell, addr, &inner_len, offset, index, source, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_cell, ckb_load_cell);
 
-int ckb_load_input(void* addr, uint64_t* len, size_t offset, size_t index,
-                   size_t source) {
+int default_ckb_load_input(void* addr, uint64_t* len, size_t offset,
+                           size_t index, size_t source) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_input, addr, &inner_len, offset, index, source, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_input, ckb_load_input);
 
-int ckb_load_header(void* addr, uint64_t* len, size_t offset, size_t index,
-                    size_t source) {
+int default_ckb_load_header(void* addr, uint64_t* len, size_t offset,
+                            size_t index, size_t source) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_header, addr, &inner_len, offset, index, source, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_header, ckb_load_header);
 
-int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
-                     size_t source) {
+int default_ckb_load_witness(void* addr, uint64_t* len, size_t offset,
+                             size_t index, size_t source) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_witness, addr, &inner_len, offset, index, source, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_witness, ckb_load_witness);
 
-int ckb_load_script(void* addr, uint64_t* len, size_t offset) {
+int default_ckb_load_script(void* addr, uint64_t* len, size_t offset) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_script, addr, &inner_len, offset, 0, 0, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_script, ckb_load_script);
 
-int ckb_load_transaction(void* addr, uint64_t* len, size_t offset) {
+int default_ckb_load_transaction(void* addr, uint64_t* len, size_t offset) {
   volatile uint64_t inner_len = *len;
   int ret =
       syscall(SYS_ckb_load_transaction, addr, &inner_len, offset, 0, 0, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_transaction, ckb_load_transaction);
 
-int ckb_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
-                           size_t index, size_t source, size_t field) {
+int default_ckb_load_cell_by_field(void* addr, uint64_t* len, size_t offset,
+                                   size_t index, size_t source, size_t field) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_cell_by_field, addr, &inner_len, offset, index,
                     source, field);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_cell_by_field, ckb_load_cell_by_field);
 
-int ckb_load_header_by_field(void* addr, uint64_t* len, size_t offset,
-                             size_t index, size_t source, size_t field) {
+int default_ckb_load_header_by_field(void* addr, uint64_t* len, size_t offset,
+                                     size_t index, size_t source,
+                                     size_t field) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_header_by_field, addr, &inner_len, offset,
                     index, source, field);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_header_by_field, ckb_load_header_by_field);
 
-int ckb_load_input_by_field(void* addr, uint64_t* len, size_t offset,
-                            size_t index, size_t source, size_t field) {
+int default_ckb_load_input_by_field(void* addr, uint64_t* len, size_t offset,
+                                    size_t index, size_t source, size_t field) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_input_by_field, addr, &inner_len, offset,
                     index, source, field);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_input_by_field, ckb_load_input_by_field);
 
-int ckb_load_cell_data(void* addr, uint64_t* len, size_t offset, size_t index,
-                       size_t source) {
+int default_ckb_load_cell_data(void* addr, uint64_t* len, size_t offset,
+                               size_t index, size_t source) {
   volatile uint64_t inner_len = *len;
   int ret = syscall(SYS_ckb_load_cell_data, addr, &inner_len, offset, index,
                     source, 0);
   *len = inner_len;
   return ret;
 }
+weak_alias(default_ckb_load_cell_data, ckb_load_cell_data);
 
-int ckb_load_cell_data_as_code(void* addr, size_t memory_size,
-                               size_t content_offset, size_t content_size,
-                               size_t index, size_t source) {
+int default_ckb_load_cell_data_as_code(void* addr, size_t memory_size,
+                                       size_t content_offset,
+                                       size_t content_size, size_t index,
+                                       size_t source) {
   return syscall(SYS_ckb_load_cell_data_as_code, addr, memory_size,
                  content_offset, content_size, index, source);
 }
+weak_alias(default_ckb_load_cell_data_as_code, ckb_load_cell_data_as_code);
 
-int ckb_debug(const char* s) {
+int default_ckb_debug(const char* s) {
   return syscall(SYS_ckb_debug, s, 0, 0, 0, 0, 0);
 }
+weak_alias(default_ckb_debug, ckb_debug);
 
-int ckb_vm_version() { return syscall(SYS_ckb_vm_version, 0, 0, 0, 0, 0, 0); }
+int default_ckb_vm_version() {
+  return syscall(SYS_ckb_vm_version, 0, 0, 0, 0, 0, 0);
+}
+weak_alias(default_ckb_vm_version, ckb_vm_version);
 
-uint64_t ckb_current_cycles() {
+uint64_t default_ckb_current_cycles() {
   return syscall(SYS_ckb_current_cycles, 0, 0, 0, 0, 0, 0);
 }
+weak_alias(default_ckb_current_cycles, ckb_current_cycles);
 
-int ckb_exec(size_t index, size_t source, size_t place, size_t bounds, int argc,
-             const char* argv[]) {
+int default_ckb_exec(size_t index, size_t source, size_t place, size_t bounds,
+                     int argc, const char* argv[]) {
   return syscall(SYS_ckb_exec, index, source, place, bounds, argc, argv);
 }
+weak_alias(default_ckb_exec, ckb_exec);
 
-int ckb_spawn(size_t index, size_t source, size_t place, size_t bounds,
-              spawn_args_t* spawn_args) {
+int default_ckb_spawn(size_t index, size_t source, size_t place, size_t bounds,
+                      spawn_args_t* spawn_args) {
   return syscall(SYS_ckb_spawn, index, source, place, bounds, spawn_args, 0);
 }
+weak_alias(default_ckb_spawn, ckb_spawn);
 
-int ckb_wait(uint64_t pid, int8_t* exit_code) {
+int default_ckb_wait(uint64_t pid, int8_t* exit_code) {
   return syscall(SYS_ckb_wait, pid, exit_code, 0, 0, 0, 0);
 }
+weak_alias(default_ckb_wait, ckb_wait);
 
-uint64_t ckb_process_id() {
+uint64_t default_ckb_process_id() {
   return syscall(SYS_ckb_process_id, 0, 0, 0, 0, 0, 0);
 }
+weak_alias(default_ckb_process_id, ckb_process_id);
 
-int ckb_pipe(uint64_t fds[2]) {
+int default_ckb_pipe(uint64_t fds[2]) {
   return syscall(SYS_ckb_pipe, fds, 0, 0, 0, 0, 0);
 }
+weak_alias(default_ckb_pipe, ckb_pipe);
 
-int ckb_read(uint64_t fd, void* buffer, size_t* length) {
+int default_ckb_read(uint64_t fd, void* buffer, size_t* length) {
   volatile size_t l = *length;
   int ret = syscall(SYS_ckb_read, fd, buffer, &l, 0, 0, 0);
   *length = l;
   return ret;
 }
+weak_alias(default_ckb_read, ckb_read);
 
-int ckb_write(uint64_t fd, const void* buffer, size_t* length) {
+int default_ckb_write(uint64_t fd, const void* buffer, size_t* length) {
   volatile size_t l = *length;
   int ret = syscall(SYS_ckb_write, fd, buffer, &l, 0, 0, 0);
   *length = l;
   return ret;
 }
+weak_alias(default_ckb_write, ckb_write);
 
-int ckb_load_block_extension(void* addr, uint64_t* len, size_t offset,
-                             size_t index, size_t source) {
+int default_ckb_load_block_extension(void* addr, uint64_t* len, size_t offset,
+                                     size_t index, size_t source) {
   return syscall(SYS_ckb_load_block_extension, addr, len, offset, index, source,
                  0);
 }
+weak_alias(default_ckb_load_block_extension, ckb_load_block_extension);
 
-int ckb_inherited_fds(uint64_t* fds, size_t* length) {
+int default_ckb_inherited_fds(uint64_t* fds, size_t* length) {
   volatile size_t l = *length;
   int ret = syscall(SYS_ckb_inherited_fds, fds, &l, 0, 0, 0, 0);
   *length = l;
   return ret;
 }
+weak_alias(default_ckb_inherited_fds, ckb_inherited_fds);
 
-int ckb_close(uint64_t fd) { return syscall(SYS_ckb_close, fd, 0, 0, 0, 0, 0); }
+int default_ckb_close(uint64_t fd) {
+  return syscall(SYS_ckb_close, fd, 0, 0, 0, 0, 0);
+}
+weak_alias(default_ckb_close, ckb_close);
 
 #endif /* CKB_STDLIB_NO_SYSCALL_IMPL */
 

--- a/libc/src/impl.c
+++ b/libc/src/impl.c
@@ -20,6 +20,15 @@
 #include <stdint.h>
 
 /*
+ * From
+ * https://git.musl-libc.org/cgit/musl/tree/src/include/features.h?id=86373b4999bfd9a9379bc4a3ca877b1c80a2a340#n8
+ */
+#ifndef weak_alias
+#define weak_alias(old, new) \
+  extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+#endif
+
+/*
  * The implementation here is based on musl-libc with modifications for our
  * use case. The original musl-libc follows MIT license, thanks to the authors
  * for the creation.
@@ -329,10 +338,14 @@ void free(void *ptr);
 void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);
 #else
-void *malloc(size_t size) { return NULL; }
-void free(void *ptr) {}
-void *calloc(size_t nmemb, size_t size) { return NULL; }
-void *realloc(void *ptr, size_t size) { return NULL; }
+void *failure_malloc(size_t size) { return NULL; }
+weak_alias(failure_malloc, malloc);
+void failure_free(void *ptr) {}
+weak_alias(failure_free, free);
+void *failure_calloc(size_t nmemb, size_t size) { return NULL; }
+weak_alias(failure_calloc, calloc);
+void *failure_realloc(void *ptr, size_t size) { return NULL; }
+weak_alias(failure_realloc, realloc);
 #endif
 
 /*


### PR DESCRIPTION
In certain cases(such as fuzzing, or native simulator as used in Rust), we need to stub `ecall`-based syscall invocations with other functions.

In previous designs it requires us to omit the including of `ckb_raw_syscalls.h`, and link against our own stubs.

It turns out that this process can be quite tedious requiring changing in a lot of different code, in many cases it is not the ideal solution.

And it just occured to me that we can simply [weak alias](https://en.wikipedia.org/wiki/Weak_symbol) those syscall implementations, so when a custom one is linked, the custom one will be picked by the linker. Otherwise the default(weak) one will be used.

In fact the `weak_alias` technique has been widely used in musl libc / glibc at least, so it is not something that will go away with time.

In this new design, stubing syscalls in most cases will simply become:

* Upgrade ckb-c-stdlib to latest revision, typically this requires no changes to the code.
* Custom syscall impls are then compiled and linked in the final binary, they will take effect automatically.

To me this enables a much simpler workflow for stubbing syscalls.